### PR TITLE
In progress changes for Spreedly's iOS SDK

### DIFF
--- a/CocoaSample/BankAccountFormViewController.swift
+++ b/CocoaSample/BankAccountFormViewController.swift
@@ -72,7 +72,7 @@ extension BankAccountFormViewController: SecureFormDelegate {
             success transaction: Transaction
     ) {
         let token = transaction.paymentMethod?.token ?? "empty"
-        print("My payment token is \(token)")
+        NSLog("My payment token is \(token)")
 
         displayAlert(message: "Token: \(token)", title: "Success")
     }

--- a/CocoaSample/CreditCardFormViewController.swift
+++ b/CocoaSample/CreditCardFormViewController.swift
@@ -59,7 +59,7 @@ extension CreditCardFormViewController: SecureFormDelegate {
             success transaction: Transaction
     ) {
         let token = transaction.paymentMethod?.token ?? "empty"
-        print("My payment token is \(token)")
+        NSLog("My payment token is \(token)")
 
         displayAlert(message: "Token: \(token)", title: "Success")
 

--- a/CocoaSample/ViewController.swift
+++ b/CocoaSample/ViewController.swift
@@ -29,7 +29,7 @@ extension ViewController {
             PaymentMethodItem(type: .creditCard, description: "Mastercard 1111", token: "abc456")
         ]
         builder.didSelectPaymentMethod = { item in
-            print("Payment method selected token: \(item.token)")
+            NSLog("Payment method selected token: \(item.token)")
             self.navigationController?.popToViewController(self, animated: true)
         }
 
@@ -130,7 +130,7 @@ extension ViewController {
             PaymentMethodItem(type: .creditCard, description: "MC 4444", token: "abc456")
         ]
         builder.didSelectPaymentMethod = { item in
-            print("Payment method selected token: \(item.token)")
+            NSLog("Payment method selected token: \(item.token)")
             self.dismiss(animated: true)
         }
         builder.defaultCreditCardInfo = {

--- a/Spreedly/Client.swift
+++ b/Spreedly/Client.swift
@@ -18,7 +18,7 @@ public protocol SpreedlyClient {
     
     var config: ClientConfiguration { get }
     
-    func getPlatformDataLocal() -> String
+    func getPlatformDataLocal() throws -> String
 }
 
 public enum SpreedlySecurityError: Error {

--- a/Spreedly/ClientConfiguration.swift
+++ b/Spreedly/ClientConfiguration.swift
@@ -54,4 +54,5 @@ public enum ClientError: Int, Error {
     case noSpreedlyCredentials
     case parseError
     case invalidRequestData
+    case encodingError
 }

--- a/Spreedly/Internal/JSON.swift
+++ b/Spreedly/Internal/JSON.swift
@@ -11,7 +11,7 @@ enum JSONError: Error, Equatable {
 }
 
 extension Data {
-    func decodeJson() throws -> [String: Any] {
+    func spr_decodeJson() throws -> [String: Any] {
         guard let json = try? JSONSerialization.jsonObject(with: self) as? [String: Any] else {
             throw JSONError.expectedObject
         }

--- a/Spreedly/Models/ApplePayInfo.swift
+++ b/Spreedly/Models/ApplePayInfo.swift
@@ -31,7 +31,7 @@ public class ApplePayInfo: PaymentMethodInfo {
     internal override func toJson() throws -> [String: Any] {
         var result = [String: Any]()
 
-        result["payment_data"] = try paymentToken.decodeJson()
+        result["payment_data"] = try paymentToken.spr_decodeJson()
         result.maybeSet("test_card_number", testCardNumber)
         return result
     }

--- a/Spreedly/Models/Transaction.swift
+++ b/Spreedly/Models/Transaction.swift
@@ -73,7 +73,7 @@ public class Transaction: NSObject {
     }
 
     static func unwrap(from data: Data) throws -> Transaction {
-        let json = try data.decodeJson()
+        let json = try data.spr_decodeJson()
         if json.keys.contains("transaction") {
             return Transaction(from: try json.object(for: "transaction"))
         }

--- a/SpreedlyCocoa/Express/ExpressBuilder.swift
+++ b/SpreedlyCocoa/Express/ExpressBuilder.swift
@@ -19,7 +19,7 @@ import Spreedly
 /// ```swift
 /// var builder = ExpressBuilder()
 /// builder.didSelectPaymentMethod = { item in
-///     print("User wants to use a payment method with token: \(item.token)")
+///     NSLog("User wants to use a payment method with token: \(item.token)")
 /// }
 /// let controller = builder.buildViewController()
 /// navigationController?.show(controller, sender: self)

--- a/UnitTests/BankAccountTests.swift
+++ b/UnitTests/BankAccountTests.swift
@@ -25,7 +25,7 @@ class BankAccountInfoTests: XCTestCase {
                              "bank_account_type" : "checking",
                              "bank_account_holder_type" : "personal"
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }
@@ -48,7 +48,7 @@ class BankAccountInfoTests: XCTestCase {
                              "bank_account_type" : "checking",
                              "bank_account_holder_type" : "personal"
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }

--- a/UnitTests/CreditCardTests.swift
+++ b/UnitTests/CreditCardTests.swift
@@ -31,7 +31,7 @@ class CreditCardInfoTests: XCTestCase {
                              "verification_value" : "919",
                              "year" : 2029
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }
@@ -52,7 +52,7 @@ class CreditCardInfoTests: XCTestCase {
                              "verification_value" : "919",
                              "year" : 2029
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }
@@ -74,7 +74,7 @@ class CreditCardInfoTests: XCTestCase {
                              "verification_value" : "919",
                              "year" : 2029
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }
@@ -90,7 +90,7 @@ class CreditCardInfoTests: XCTestCase {
         creditCard.allowBlankDate = true
 
         let json = try creditCard.toJson()
-        try print(String(data: json.encodeJson(), encoding: .utf8)!)
+        try NSLog(String(data: json.encodeJson(), encoding: .utf8)!)
 
         let expected = try """
                            {
@@ -99,7 +99,7 @@ class CreditCardInfoTests: XCTestCase {
                              "number" : "4111111111111111",
                              "verification_value" : "919",
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }

--- a/UnitTests/JSONExtensionsTests.swift
+++ b/UnitTests/JSONExtensionsTests.swift
@@ -11,7 +11,7 @@ class DecodeJsonTests: XCTestCase {
     func testDecodeJsonWhenNotJsonShouldThrow() {
         let notJson = "<ul><li>list item</li></ul>"
         let data = notJson.data(using: .utf8)!
-        XCTAssertThrowsError(try data.decodeJson()) { error in
+        XCTAssertThrowsError(try data.spr_decodeJson()) { error in
             XCTAssertEqual(error as? JSONError, .expectedObject)
         }
     }
@@ -21,7 +21,7 @@ class DecodeJsonTests: XCTestCase {
                         "I'm just a string"
                         """
         let data = validJson.data(using: .utf8)!
-        XCTAssertThrowsError(try data.decodeJson()) { error in
+        XCTAssertThrowsError(try data.spr_decodeJson()) { error in
             XCTAssertEqual(error as? JSONError, .expectedObject)
         }
     }
@@ -31,7 +31,7 @@ class DecodeJsonTests: XCTestCase {
                         {"key": "value"}
                         """
         let data = validJson.data(using: .utf8)!
-        let decodedObject = try data.decodeJson()
+        let decodedObject = try data.spr_decodeJson()
         XCTAssertEqual("value", try decodedObject.string(for: "key"))
     }
 }
@@ -52,7 +52,7 @@ let json = try! """
                     "int": 42,
                     "stringInt": "9001"
                 }
-                """.data(using: .utf8)!.decodeJson()
+                """.data(using: .utf8)!.spr_decodeJson()
 
 class ObjectTests: XCTestCase {
     func testWhenMissingShouldThrow() {


### PR DESCRIPTION
* replaced `print` with `NSLog`
* removed forced unwrapping in SDK
* updated `getPlatformData`
* updated `Base64EncodingOptions`
* prefixed one `Foundation` extension method
* added timeout to `URLSession`

